### PR TITLE
Added different sort options, and fixed infinite runtime bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Tired of all of those reddit downloaders which want you to install tons of depen
 - Linux/MacOS/Windows
 - Parallel download
 
-This script just downloads all directly linked images in subreddit. For more complex usage, use other reddit image downloader.
+This script just downloads all directly linked images in subreddit. It can also download with a specific sort. For more complex usage, use other reddit image downloader.
 
 Requirements
 ============
@@ -17,6 +17,10 @@ Requirements
 
 Usage
 =====
-`./download-subreddit-images.sh <subreddit_name>`
+```
+./download-subreddit-images.sh <subreddit_name>
+./download-subreddit-images.sh <subreddit_name> <hot|new|rising|top>
+./download-subreddit-images.sh <subreddit_name> top <all|year|month|week|day>
+```
 
 Script downloads images to `<subreddit_name>` folder in current directory. If you want to change that, you need to edit destination in rdit.sh for now.

--- a/download-subreddit-images.sh
+++ b/download-subreddit-images.sh
@@ -34,7 +34,7 @@ while : ; do
         wget -T $timeout -U "$useragent" --no-check-certificate -nv -nc -P down -O "$subreddit/$newname" $url &>/dev/null &
         a=$(($a+1))
     done
-    after=$(echo -n "$content"| jq -r '.data.after')
+    after=$(echo -n "$content"| jq -r '.data.after//empty')
     if [[ -z $after ]]; then
         break
     fi

--- a/download-subreddit-images.sh
+++ b/download-subreddit-images.sh
@@ -35,7 +35,7 @@ while : ; do
         a=$(($a+1))
     done
     after=$(echo -n "$content"| jq -r '.data.after//empty')
-    if [[ -z $after ]]; then
+    if [ -z $after ]; then
         break
     fi
     url="https://www.reddit.com/r/$subreddit/$sort/.json?count=200&after=$after&raw_json=1&t=$top_time"

--- a/download-subreddit-images.sh
+++ b/download-subreddit-images.sh
@@ -5,7 +5,18 @@ useragent="Love by u/gadelat"
 timeout=60
 
 subreddit=$1
-url="https://www.reddit.com/r/$subreddit/.json?raw_json=1"
+sort=$2
+top_time=$3
+
+if [ -z $sort ]; then
+    sort="hot"
+fi
+
+if [ -z $top_time ];then
+    top_time=""
+fi
+
+url="https://www.reddit.com/r/$subreddit/$sort/.json?raw_json=1&t=$top_time"
 content=`wget -T $timeout -U "$useragent" -q -O - $url`
 mkdir -p $subreddit
 while : ; do
@@ -24,10 +35,12 @@ while : ; do
         a=$(($a+1))
     done
     after=$(echo -n "$content"| jq -r '.data.after')
-    if [ -z $after ]; then
+    if [[ -z $after ]]; then
         break
     fi
-    url="https://www.reddit.com/r/$subreddit/.json?count=200&after=$after&raw_json=1"
+    if [[ $after == "null" ]]; then
+        break
+    fi
+    url="https://www.reddit.com/r/$subreddit/$sort/.json?count=200&after=$after&raw_json=1&t=$top_time"
     content=`wget -T $timeout -U "$useragent" --no-check-certificate -q -O - $url`
-    #echo -e "$urls"
 done

--- a/download-subreddit-images.sh
+++ b/download-subreddit-images.sh
@@ -38,9 +38,6 @@ while : ; do
     if [[ -z $after ]]; then
         break
     fi
-    if [[ $after == "null" ]]; then
-        break
-    fi
     url="https://www.reddit.com/r/$subreddit/$sort/.json?count=200&after=$after&raw_json=1&t=$top_time"
     content=`wget -T $timeout -U "$useragent" --no-check-certificate -q -O - $url`
 done


### PR DESCRIPTION
I've added second and third arguments so that you can choose the sort of the page. The arguments `aww top all` will return the top posts of all time from r/aww, and `aww new` will start searching for images on the new page.

I also noticed that the script runs indefinitely, because the `if [ -z $after ]` check doesn't work, there will always be a value for `$after`. The correct bad value is `null`, so I added a check for that and it successfully exits now.